### PR TITLE
Modified the data processing workflow to handle multiple splits simultaneously.

### DIFF
--- a/pikerag/data_process/config/datasets.yaml
+++ b/pikerag/data_process/config/datasets.yaml
@@ -21,11 +21,8 @@ cut_off: null
 datasets:
   # nq: validation
   # triviaqa: validation
-  hotpotqa: dev
-  two_wiki: dev
+  hotpotqa: [dev, train]
+  two_wiki: [dev, train]
   # popqa: test
   # webqa: test
-  musique: dev
-  hotpotqa: train
-  two_wiki: train
-  musique: train
+  musique: [dev, train]

--- a/pikerag/main.py
+++ b/pikerag/main.py
@@ -44,11 +44,12 @@ if __name__ == "__main__":
     # Read yaml configs
     root_save_dir: str = yaml_config["root_save_dir"]
     running_modes: Dict[str, bool] = yaml_config["running_modes"]
-    dataset2split: Dict[str, str] = yaml_config["datasets"]
+    dataset2split: Dict[str, List[str]] = yaml_config["datasets"]
 
     # Check dataset split setting.
-    for dataset, split in dataset2split.items():
-        check_dataset_split(dataset, split)
+    for dataset, splits in dataset2split.items():
+        for split in splits:
+            check_dataset_split(dataset, split)
 
     # Create directories for processed data saving.
     create_dirs(root_save_dir, list(dataset2split.keys()))
@@ -56,10 +57,11 @@ if __name__ == "__main__":
     # Build up QA data.
     if running_modes["build_split"]:
         cut_off: Optional[int] = yaml_config["cut_off"]
-        for dataset, split in dataset2split.items():
-            dataset_dir: str = get_dataset_dir(root_save_dir, dataset)
-            split_path: str = get_split_filepath(root_save_dir, dataset, split, sample_num=None)
-            reformat_dataset(dataset, split, split_path, dataset_dir, cut_off)
+        for dataset, splits in dataset2split.items():
+            for split in splits:
+                dataset_dir: str = get_dataset_dir(root_save_dir, dataset)
+                split_path: str = get_split_filepath(root_save_dir, dataset, split, sample_num=None)
+                reformat_dataset(dataset, split, split_path, dataset_dir, cut_off)
 
     # # Sample and download valid samples and docs for each dataset.
     # if running_modes["sample_sets"]:


### PR DESCRIPTION
After successfully running `bash download_data.sh`, I noticed that the `dev` split was missing during the execution of `data_processing.sh`. Upon investigation, I found that in the `pikerag/data_process/config/dataset/yaml` configuration file, each dataset name was associated with a single split **twice**. However, the assignment of the train split later in the process unintentionally overwrote the earlier `dev` split, resulting in only the `train` split being passed as input.

To resolve this, I updated the configuration file to allow the split field to accept a list. I also made a minor modification to the main script to accommodate this change.

Best,
Yibo Zhao